### PR TITLE
Fixing duplicate item bug

### DIFF
--- a/db/init-admin.js
+++ b/db/init-admin.js
@@ -1,6 +1,11 @@
 const adminService = require("../services/admin-service");
 
-adminService.createUser("PREORDER", "admin");
-if(process.env.DEFAULT_ADMIN) {
-    adminService.createUser(process.env.DEFAULT_ADMIN, "admin");
+const initAdmin = async() => {
+    await adminService.createUser("PREORDER", "admin");
+    if(process.env.DEFAULT_ADMIN) {
+        await adminService.createUser(process.env.DEFAULT_ADMIN, "admin");
+    }
+    process.exit(0);
 }
+
+initAdmin();

--- a/models/items.js
+++ b/models/items.js
@@ -6,13 +6,14 @@ exports.init_table = function (sequelize) {
             type: Sequelize.INTEGER,
             autoIncrement: true,
             require: true,
-            primaryKey: true
+            unique: true,
         },
         name: {
             type: Sequelize.STRING,
             allowNull: false,
             require: true,
-            unique: false,
+            unique: "nameDescConstraint",
+            primaryKey: true,
         },
 		barcode: {
             type: Sequelize.STRING,
@@ -34,7 +35,8 @@ exports.init_table = function (sequelize) {
             type: Sequelize.STRING,
             allowNull: true,
             require: false,
-            unique: false,
+            unique: "nameDescConstraint",
+            primaryKey: true,
         }
     });
 }

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -1,6 +1,7 @@
 const   Item = require("../db/sequelize").items,
         Transaction = require("../db/sequelize").transactions,
         Sequelize = require("sequelize"),
+        sequelize = require("../db/sequelize"),
         BadRequestException = require("../exceptions/bad-request-exception"),
         InternalErrorException = require("../exceptions/internal-error-exception"),
         CarolinaCupboardException = require("../exceptions/carolina-cupboard-exception"),
@@ -125,11 +126,10 @@ exports.appendCsv = async function (data) {
                 escapeChar: '"', 
                 enclosedChar: '"'
             }, 
-            function(err, output) {
+            async function(err, output) {
                 if (err) {
                     throw new InternalErrorException("A problem occurred when parsing CSV data");
                 }
-                let newItems = [];
                 output.forEach(function(entry) {
                     try {
                         let item = {
@@ -143,12 +143,11 @@ exports.appendCsv = async function (data) {
                             item.barcode = null;
                         }
 
-                        newItems.push(item);
+                        Item.upsert(item);
                     } catch (e) {
                         throw e;
                     }
                 });
-                Item.bulkCreate(newItems);
             }
         );
     } catch(e) {


### PR DESCRIPTION
Tracked in issue #16 

Changes:
- Made `name` and `description` a composite primary key in the `Items` table. The previous primary key `id` is now just a unique field.
- Changed CSV import to use individual upserts because bulk upsert does not work with composite unique constraints at the moment.

Note: Merge must wait until we talk to Carolina Cupboard and fix the existing duplicate items.