### PR TITLE
Accept CSV import format as exported by the CSV backup feature

### DIFF
--- a/services/item-service.js
+++ b/services/item-service.js
@@ -130,7 +130,7 @@ exports.appendCsv = async function (data) {
                     throw new InternalErrorException("A problem occurred when parsing CSV data");
                 }
                 let newItems = [];
-                for(let i = 1; i < output.length; i++) {
+                for(let i = 0; i < output.length; i++) {
                     let entry = output[i];
                     if (entry.length === 7 && i === 0) continue;
                     try {

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -130,15 +130,29 @@ exports.appendCsv = async function (data) {
                     throw new InternalErrorException("A problem occurred when parsing CSV data");
                 }
                 let newItems = [];
-                output.forEach(function(entry) {
+                for(let i = 1; i < output.length; i++) {
+                    let entry = output[i];
+                    if (entry.length === 7 && i === 0) continue;
                     try {
-                        let item = {
-                            name: entry[0],
-                            barcode: entry[1],
-                            count: entry[2],
-                            description: entry[3],
+                        let item = {};
+                        if (entry.length === 4) {
+                            item = {
+                                name: entry[0],
+                                barcode: entry[1],
+                                count: entry[2],
+                                description: entry[3],
+                            }
                         }
-                        
+                        // Expects a file with the same format as an exported file
+                        else if (entry.length === 7) {
+                            item = {
+                                name: entry[1],
+                                barcode: entry[2],
+                                count: entry[3],
+                                description: entry[4],
+                            }
+                        }
+                            
                         if (entry[1] === "") {
                             item.barcode = null;
                         }
@@ -147,7 +161,7 @@ exports.appendCsv = async function (data) {
                     } catch (e) {
                         throw e;
                     }
-                });
+                }
                 Item.bulkCreate(newItems);
             }
         );

--- a/views/admin/entry-import.ejs
+++ b/views/admin/entry-import.ejs
@@ -13,9 +13,18 @@
     <% } %>
     <h2>Import Items</h2>
     <div class="row">
-      <div class="col-sm-6">
+      <div class="col-sm-12">
         <div class="alert alert-secondary">
-          <p>Expected format: item name, barcode, quantity, item description</p>
+          <p>Expected formats:</p>
+          <ul>
+            <li>item name, barcode, quantity, item description</li>
+            <li>item id, item name, barcode, count, item description, createdAt, updatedAt (export format)</li>
+          </ul>
+          <p>The following fields are required:</p>
+          <ul>
+            <li>item name</li>
+            <li>count</li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Tracked in issue #19 

Changes:
1. Along with existing CSV import format, the import feature now accepts files of the same format that the CSV export function produces