### PR TITLE
Duplicate item import fix with add on duplicate

### DIFF
--- a/controllers/entry.js
+++ b/controllers/entry.js
@@ -82,7 +82,7 @@ router.get("/manual", async function(req, res) {
             response.infoMessage = "Item successfully updated!"
         }
     }
-    console.log(response);
+ 
     let foundItem = {
         name: req.query.name,
         barcode: req.query.barcode,
@@ -100,12 +100,11 @@ router.post('/manual', async function(req, res) {
     let response = {};
     try {
         let name = req.body.name;
-        let barcode = req.body.barcode;
+        let barcode = req.body.barcode === "" ? null : req.body.barcode;
         let description = req.body.description;
         let count = req.body.count;
 
         if(barcode || name) {
-            console.log(barcode);
             // try searching by barcode, then by name and desc
             let item = await itemService.getItemByBarcodeThenNameDesc(barcode, name, description);
             console.log(item);

--- a/models/items.js
+++ b/models/items.js
@@ -6,13 +6,14 @@ exports.init_table = function (sequelize) {
             type: Sequelize.INTEGER,
             autoIncrement: true,
             require: true,
-            primaryKey: true
+            unique: true,
         },
         name: {
             type: Sequelize.STRING,
             allowNull: false,
             require: true,
-            unique: false,
+            unique: "nameDescConstraint",
+            primaryKey: true,
         },
 		barcode: {
             type: Sequelize.STRING,
@@ -34,7 +35,8 @@ exports.init_table = function (sequelize) {
             type: Sequelize.STRING,
             allowNull: true,
             require: false,
-            unique: false,
+            unique: "nameDescConstraint",
+            primaryKey: true,
         }
     });
 }

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -1,6 +1,7 @@
 const   Item = require("../db/sequelize").items,
         Transaction = require("../db/sequelize").transactions,
         Sequelize = require("sequelize"),
+        sequelize = require("../db/sequelize"),
         BadRequestException = require("../exceptions/bad-request-exception"),
         InternalErrorException = require("../exceptions/internal-error-exception"),
         CarolinaCupboardException = require("../exceptions/carolina-cupboard-exception"),
@@ -98,9 +99,10 @@ exports.getItemByBarcodeThenNameDesc = async function (barcode, name, desc) {
 
 /*
 Looks for an item by barcode
-Returns the item fround or null if nothing is found
+Returns the item found or null if nothing is found
 */
 let getItemByBarcode = async function (barcode) {
+    if (!barcode || barcode === "") return null;
     try {
         let item = await Item.findOne({ where: { barcode: barcode }});
         return item;
@@ -155,6 +157,8 @@ exports.createTransaction = async function (itemId, quantity, onyen, volunteerId
     }
 }
 
+// Appends a given CSV to the item table
+// On duplicate, adds the existing count and the new count together
 exports.appendCsv = async function (data) {
     // wrapping everything in a Promise, so we can return exceptions from the csvParser callback
     // this will allow the caller to tell when the Item table creation fails
@@ -171,47 +175,56 @@ exports.appendCsv = async function (data) {
                     if (err) {
                         throw new InternalErrorException("A problem occurred when parsing CSV data");
                     }
+
                     let newItems = [];
                     for(let i = 0; i < output.length; i++) {
                         let entry = output[i];
+
+                        // Skip row headers
                         if (entry.length === 7 && i === 0) continue;
-                        try {
-                            let item = {};
-                            if (entry.length === 4) {
-                                item = {
-                                    name: entry[0],
-                                    barcode: entry[1],
-                                    count: entry[2],
-                                    description: entry[3],
-                                }
-                            }
-                            // Expects a file with the same format as an exported file
-                            else if (entry.length === 7) {
-                                item = {
-                                    name: entry[1],
-                                    barcode: entry[2],
-                                    count: entry[3],
-                                    description: entry[4],
-                                }
-                            }
 
-                            if (entry[1] === "") {
-                                item.barcode = null;
-                            }
+                        let item = "";
 
-                            newItems.push(item);
-                        } catch (e) {
-                            console.error(e);
+                        // Generate date for createdAt and updatedAt fields and strip timezone for Postgres
+                        let date = new Date();
+                        date = date.toLocaleDateString() + " " + date.toLocaleTimeString();
+
+                        // Expects a file with only the necessary data
+                        if (entry.length === 4) {
+                            // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
+                            let barcode = entry[1] === "" ? "NULL" : "'" + entry[1] + "'";
+                            // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
+                            item = "(" + [entry[0], barcode, entry[2], entry[3], date, date].map((s,i) => { return i === 1 ? s : "'"+s+"'" }).join(",") + ")";
+                        }
+                        // Expects a file with the same format as an exported file
+                        else if (entry.length === 7) {
+                            // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
+                            let barcode = entry[2] === "" ? "NULL" : "'" + entry[2] + "'";
+                            // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
+                            item = "(" + [entry[1], barcode, entry[3], entry[4], date, date].map((s,i) => { return i === 1 ? s : "'"+s+"'" }).join(",") + ")";
+                        }
+                        else {
+                            console.error("File not in the expected format, see line " + (i+1));
                             reject(e);
                         }
+
+                        newItems.push(item);
                     }
 
-                    Item.bulkCreate(newItems).then(function(result) {
-                        resolve(result);
-                    }).catch(function(e) {
-                        console.error(e);
-                        reject(e);
-                    });
+                    // Execute query, on conflict with name/desc composite primary key, add existing and new counts
+                    sequelize.query(`INSERT INTO items (name, barcode, count, description, "createdAt", "updatedAt") 
+                                    VALUES ${newItems}
+                                    ON CONFLICT (name, description)
+                                    DO UPDATE
+                                    SET count = items.count + EXCLUDED.count`,
+                                    {
+                                        replacements: newItems
+                                    }).then(function(result) {
+                                        resolve(result);
+                                    }).catch(function(e) {
+                                        console.error(e);
+                                        reject(e);
+                                    });
                 }
             );
         } catch(e) {

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -190,6 +190,7 @@ exports.appendCsv = async function (data) {
 
                         // Expects a file with only the necessary data
                         if (entry.length === 4) {
+                            if (parseInt(entry[2]) < 1) continue;
                             // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
                             let barcode = entry[1] === "" ? "NULL" : "'" + entry[1] + "'";
                             // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
@@ -198,6 +199,7 @@ exports.appendCsv = async function (data) {
                         }
                         // Expects a file with the same format as an exported file
                         else if (entry.length === 7) {
+                            if (parseInt(entry[3]) < 1) continue;
                             // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
                             let barcode = entry[2] === "" ? "NULL" : "'" + entry[2] + "'";
                             // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
@@ -205,8 +207,9 @@ exports.appendCsv = async function (data) {
                             item = "(" + [entry[1], barcode, entry[3], entry[4], date, date].map((s,i) => { return i === 1 ? s : "'"+s.replace(/'/g, "''")+"'" }).join(",") + ")";
                         }
                         else {
-                            console.error("File not in the expected format, see line " + (i+1));
-                            reject(e);
+                            let error = "File not in the expected format, see line " + (i+1);
+                            console.error(error);
+                            reject(error);
                         }
 
                         // Execute query, on conflict with name/desc composite primary key, add existing and new counts

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -193,14 +193,16 @@ exports.appendCsv = async function (data) {
                             // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
                             let barcode = entry[1] === "" ? "NULL" : "'" + entry[1] + "'";
                             // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
-                            item = "(" + [entry[0], barcode, entry[2], entry[3], date, date].map((s,i) => { return i === 1 ? s : "'"+s+"'" }).join(",") + ")";
+                            // Postgres uses double single quotes to escape single quotes in strings, so we do a replace
+                            item = "(" + [entry[0], barcode, entry[2], entry[3], date, date].map((s,i) => { return i === 1 ? s : "'"+s.replace(/'/g, "''")+"'" }).join(",") + ")";
                         }
                         // Expects a file with the same format as an exported file
                         else if (entry.length === 7) {
                             // Empty barcode maps to NULL for our Postgres model, pre-wrap with single quotes
                             let barcode = entry[2] === "" ? "NULL" : "'" + entry[2] + "'";
                             // Prep values for query by enclosing in paren, wrapping in single quotes (except barcode), and joining by comma
-                            item = "(" + [entry[1], barcode, entry[3], entry[4], date, date].map((s,i) => { return i === 1 ? s : "'"+s+"'" }).join(",") + ")";
+                            // Postgres uses double single quotes to escape single quotes in strings, so we do a replace
+                            item = "(" + [entry[1], barcode, entry[3], entry[4], date, date].map((s,i) => { return i === 1 ? s : "'"+s.replace(/'/g, "''")+"'" }).join(",") + ")";
                         }
                         else {
                             console.error("File not in the expected format, see line " + (i+1));


### PR DESCRIPTION
Adds features/fixes bugs requested in #17 

Changes:
- Updated schema with (`name`, `description`) as the composite primary key. 
    - The previous primary key, `id` is now a unique field.
- Changed CSV import to add the existing and new `count` values in the case of a duplicate.
    - We use a raw query for this. We cannot use `bulkCreate` with `updateOnDuplicate` because it only allows us to set updated fields to the excluded value, which does not allow us to add values in the way Carolina Cupboard wants.
    - If Sequelize updates with new features this should be revisited.
- Fixed an issue in manual entry where empty `barcode` values were being inserted instead of NULL, and empty `barcode` values were used to get false positives on existing items.