### PR TITLE
Added error checking for foreign key constraints on items and users

### DIFF
--- a/controllers/admin.js
+++ b/controllers/admin.js
@@ -274,15 +274,35 @@ router.get('/backup/volunteers.csv', [userIsAuthenticated, userIsAdmin], async f
 
 router.post('/delete/items/all', [userIsAuthenticated, userIsAdmin], async function (req, res, next) {
     let response = { 'table': 'items' };
-    await itemService.deleteAllItems();
-    response.success = true;
+    try {
+        await itemService.deleteAllItems();
+        response.success = true;
+    } catch (e) {
+        if (e.name === "SequelizeForeignKeyConstraintError") {
+            response.success = false;
+            response.error = "You tried to delete an item that exists in a transaction! You must backup and delete the transactions first.";
+        } else {
+            response.success = false;
+            response.error = "Unknown Error!";
+        }
+    }
     res.render('admin/admin-delete-confirm.ejs', { response: response, onyen: res.locals.onyen, userType: res.locals.userType });
 });
 
 router.post('/delete/items/outofstock', [userIsAuthenticated, userIsAdmin], async function (req, res, next) {
     let response = { 'table': 'out of stock items' };
-    await itemService.deleteOutOfStock();
-    response.success = true;
+    try {
+        await itemService.deleteOutOfStock();
+        response.success = true;
+    } catch (e) {
+        if (e.name === "SequelizeForeignKeyConstraintError") {
+            response.success = false;
+            response.error = "You tried to delete an item that exists in a transaction! You must backup and delete the transactions first.";
+        } else {
+            response.success = false;
+            response.error = "Unknown Error!";
+        }
+    }
     res.render('admin/admin-delete-confirm.ejs', { response: response, onyen: res.locals.onyen, userType: res.locals.userType });
 });
 
@@ -295,7 +315,18 @@ router.post('/delete/transactions', [userIsAuthenticated, userIsAdmin], async fu
 
 router.post('/delete/users', [userIsAuthenticated, userIsAdmin], async function (req, res, next) {
     let response = { 'table': 'users' };
-    await adminService.deleteAllUsers();
+    try {
+        await adminService.deleteAllUsers();
+        response.success = true;
+    } catch (e) {
+        if (e.name === "SequelizeForeignKeyConstraintError") {
+            response.success = false;
+            response.error = "You tried to delete a user that exists in a transaction! You must backup and delete the transactions first.";
+        } else {
+            response.success = false;
+            response.error = "Unknown Error!";
+        }
+    }
     response.success = true;
     res.render('admin/admin-delete-confirm.ejs', { response: response, onyen: res.locals.onyen, userType: res.locals.userType });
 });

--- a/db/sequelize.js
+++ b/db/sequelize.js
@@ -11,7 +11,7 @@ if (!process.env.DATABASE_URL) {
 let options = {
     dialect: 'postgres',
     pool: {
-        max: 4,
+        max: 3,
         min: 0,
         acquire: 30000,
         idle: 10000

--- a/services/item-service.js
+++ b/services/item-service.js
@@ -248,6 +248,10 @@ exports.deleteAllItems = async function() {
             truncate: false
         });
     } catch(e) {
+        if (e.name === "SequelizeForeignKeyConstraintError") {
+            throw e;
+        }
+
         if(e instanceof CarolinaCupboardException) {
             throw e;
         }
@@ -256,7 +260,7 @@ exports.deleteAllItems = async function() {
     }
 }
 
-exports.deleteOutOfStock = async function() {
+exports.deleteOutOfStock = async function() {   
     try {
         await Item.destroy({
             where: {

--- a/services/transaction-service.js
+++ b/services/transaction-service.js
@@ -15,7 +15,7 @@ exports.getAllTransactions = async function () {
         // throw e;
         throw new InternalErrorException("A problem occurred when retrieving the transaction", e);
     }
-}
+};
 
 exports.getUserPurchaseHistory = async function(onyen) {
     try {
@@ -33,7 +33,7 @@ exports.getUserPurchaseHistory = async function(onyen) {
         
         throw new InternalErrorException("A problem occurred when retrieving the transaction", e);
     }
-}
+};
 
 exports.deleteAllTransactions = async function() {
     try {
@@ -48,4 +48,4 @@ exports.deleteAllTransactions = async function() {
         
         throw new InternalErrorException("A problem occurred when deleting the transactions", e);
     }
-}
+};

--- a/views/admin/admin-delete-confirm.ejs
+++ b/views/admin/admin-delete-confirm.ejs
@@ -15,7 +15,9 @@
       <a href="/admin/backup" type="button" class="btn btn-primary">Back to Backup & Delete page</a>
     <% } else {%>
       <div class="alert alert-danger" role="alert">
-        <p>Sorry, there was an error with your request. Please try again later or contact technical support.</p>
+        <p>Sorry, there was an error with your request.
+            <%= response.error %>
+            Please try again later or contact technical support.</p>
       </div>
       <a href="/admin/backup" type="button" class="btn btn-primary">Back to Backup & Delete page</a>
     <% } %>


### PR DESCRIPTION
Related to #7 

Changes:
- Added error checking for foreign key errors when deleting items and users
- Passes those error messages up to the frontend
- Decreased Sequelize pool max connections from 4 to 3 to alleviate testing woes